### PR TITLE
use userId instead of digging into a potentially undefined user hash

### DIFF
--- a/server.js
+++ b/server.js
@@ -267,7 +267,8 @@ _RESTstop.prototype._apply = function (context, name, args, handler_name) {
 
     var invocation = new MethodInvocation({
       isSimulation: false,
-      userId: context.user._id, setUserId: setUserId,
+      userId: userId,
+      setUserId: setUserId,
       sessionData: self.sessionData
     });
 


### PR DESCRIPTION
Ran into this issue with liquid.  If `use_auth` is falsy, a user object does not get added to the context that eventually gets applied to methods using `RESTstop.call()` or `RESTstop.apply()`.

Meteor method calls made via these two methods silently fail when trying to assign the userId property to the anonymous object passed into `new MethodInvocation` and the Meteor method never ends up being invoked.

THE FIX: `userId` already gets safely set above, so if we just use that instead, everything works out.
