### PR TITLE
added check for already existing content-type header

### DIFF
--- a/server.js
+++ b/server.js
@@ -190,7 +190,7 @@ _RESTstop.prototype._start = function(){
         } else {
           output = JSON.stringify(output);
         }
-        if (res.getHeader("Content-Type")) {
+        if (!res.getHeader("Content-Type")) {
           res.setHeader("Content-Type", "text/json");
         }
       }


### PR DESCRIPTION
The content-type is forced so if you set the content-type, including charset, it would be overwritten.

A simple check if the content-type is set prevents this.
