### PR TITLE
Allow PATCH method in api requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -51,7 +51,7 @@ _RESTstop.prototype.match = function(request, response) {
       for (var key in context.params)
         args.push(context.params[key]);
 
-      if(request.method == "POST" || request.method == "PUT") {
+      if(request.method == "POST" || request.method == "PUT" || request.method == "PATCH") {
         _.extend(context.params, request.body);
       }
       if(request.method == "GET" || _.size(request.query)) {


### PR DESCRIPTION
Commit message: 

PATCH is an HTTP method used for partially updating a resource, and can
include URL parameters as well as a request body. For more information
on the PATCH method, see RFC 5789 (http://tools.ietf.org/html/rfc5789).

Notes:

This is a tiny update, tested and functioning on my own api that is using RESTstop2. If you'd rather just make the edit yourself instead of merging in the pull request that's fine. Please just let me know if you decide to make the update so I can switch back to using the official package for now. I know it's deprecated, but until I roll my own I'll continue to use your RESTstop2 package.

This is also my first pull request, so if I've done something wrong, please forgive me.  
